### PR TITLE
Implement basic agent HTTP clients

### DIFF
--- a/agent_client.py
+++ b/agent_client.py
@@ -1,0 +1,67 @@
+"""HTTP client interfaces for communicating with other agents."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urljoin
+
+import requests
+
+
+class BaseAgentClient:
+    """Simple HTTP client with basic GET/POST helpers."""
+
+    def __init__(self, base_url: str, timeout: int = 5) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    # --------------------------------------------------------------
+    def _request(self, method: str, path: str, **kwargs) -> requests.Response:
+        url = urljoin(self.base_url + "/", path.lstrip("/"))
+        kwargs.setdefault("timeout", self.timeout)
+        if method == "GET":
+            resp = requests.get(url, **kwargs)
+        elif method == "POST":
+            resp = requests.post(url, **kwargs)
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+        resp.raise_for_status()
+        return resp
+
+    # --------------------------------------------------------------
+    def get(self, path: str, **kwargs) -> str:
+        return self._request("GET", path, **kwargs).text
+
+    # --------------------------------------------------------------
+    def post(self, path: str, json_data: dict | None = None, **kwargs) -> str:
+        return self._request("POST", path, json=json_data, **kwargs).text
+
+
+class IngestAgentClient(BaseAgentClient):
+    """Client for the ingest agent."""
+
+    def discover(self, feed_url: str) -> list[str]:
+        resp = self.post("/discover", {"feed_url": feed_url})
+        try:
+            data = json.loads(resp)
+        except json.JSONDecodeError:
+            return []
+        return data.get("audio_urls", [])
+
+    def transcribe(self, audio_url: str) -> str:
+        return self.post("/transcribe", {"audio_url": audio_url})
+
+
+class StrategyAgentClient(BaseAgentClient):
+    """Client for the strategy agent."""
+
+    def analyze(self, text: str) -> str:
+        return self.post("/analyze", {"text": text})
+
+    def score(self, text: str) -> int:
+        resp = self.post("/score", {"text": text})
+        try:
+            data = json.loads(resp)
+            return int(data.get("score", 0))
+        except (json.JSONDecodeError, ValueError):
+            return 0

--- a/requests.py
+++ b/requests.py
@@ -9,3 +9,7 @@ class Response:
 
 def get(url, timeout=5):
     return Response()
+
+
+def post(url, json=None, timeout=5):
+    return Response()

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -1,0 +1,50 @@
+import json
+from agent_client import IngestAgentClient, StrategyAgentClient
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+def test_ingest_client(monkeypatch):
+    calls = {}
+
+    def fake_post(url, *args, **kwargs):
+        json_payload = kwargs.get("json")
+        if url.endswith("/discover"):
+            calls["discover"] = json_payload
+            return DummyResponse(json.dumps({"audio_urls": ["a.mp3"]}))
+        if url.endswith("/transcribe"):
+            calls["transcribe"] = json_payload
+            return DummyResponse("ok")
+        raise AssertionError("Unexpected URL")
+
+    monkeypatch.setattr("agent_client.requests.post", fake_post)
+
+    client = IngestAgentClient("http://ingest")
+    urls = client.discover("http://feed")
+    assert urls == ["a.mp3"]
+    result = client.transcribe("a.mp3")
+    assert result == "ok"
+    assert calls["discover"] == {"feed_url": "http://feed"}
+    assert calls["transcribe"] == {"audio_url": "a.mp3"}
+
+
+def test_strategy_client(monkeypatch):
+    def fake_post(url, *args, **kwargs):
+        if url.endswith("/analyze"):
+            return DummyResponse("summary")
+        if url.endswith("/score"):
+            return DummyResponse(json.dumps({"score": 5}))
+        raise AssertionError
+
+    monkeypatch.setattr("agent_client.requests.post", fake_post)
+
+    client = StrategyAgentClient("http://strategy")
+    assert client.analyze("hi") == "summary"
+    assert client.score("hi") == 5


### PR DESCRIPTION
## Summary
- add base `agent_client` framework
- extend `requests` helper with POST
- test ingest and strategy agent client flows

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68479ccdad1c8327a6fb83acbc6350a5