### PR TITLE
Implement pipeline orchestrator

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,5 +1,8 @@
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import Any, Optional
+
+from agent_client import IngestAgentClient, StrategyAgentClient
 
 async def run_task(task: Callable[[], Awaitable[None]]) -> None:
     await task()
@@ -10,3 +13,54 @@ async def run_sequential(tasks: list[Callable[[], Awaitable[None]]]) -> None:
 
 async def run_parallel(tasks: list[Callable[[], Awaitable[None]]]) -> None:
     await asyncio.gather(*(run_task(t) for t in tasks))
+
+
+class PipelineOrchestrator:
+    """Coordinate ingest and strategy agents for end-to-end execution."""
+
+    def __init__(
+        self,
+        ingest: IngestAgentClient,
+        strategy: StrategyAgentClient,
+        retries: int = 1,
+    ) -> None:
+        self.ingest = ingest
+        self.strategy = strategy
+        self.retries = retries
+
+    # ----------------------------------------------------------
+    def _call_with_retry(self, func: Callable[..., Any], *args: Any) -> Optional[Any]:
+        for attempt in range(self.retries + 1):
+            try:
+                return func(*args)
+            except Exception:  # pragma: no cover - external call failure
+                if attempt >= self.retries:
+                    return None
+
+    # ----------------------------------------------------------
+    async def _process_url(self, url: str) -> Optional[dict[str, Any]]:
+        transcript = self._call_with_retry(self.ingest.transcribe, url)
+        if not transcript:
+            return None
+        summary = self._call_with_retry(self.strategy.analyze, transcript)
+        if summary is None:
+            return None
+        return {"url": url, "summary": summary}
+
+    # ----------------------------------------------------------
+    async def run(self, feed_url: str, limit: int = 10, parallel: bool = False) -> list[dict[str, Any]]:
+        urls = self._call_with_retry(self.ingest.discover, feed_url) or []
+        results: list[dict[str, Any]] = []
+
+        async def handler(url: str) -> None:
+            res = await self._process_url(url)
+            if res:
+                results.append(res)
+
+        tasks = [lambda u=u: handler(u) for u in urls[:limit]]
+        if parallel:
+            await run_parallel(tasks)
+        else:
+            await run_sequential(tasks)
+
+        return results

--- a/run_workflow.py
+++ b/run_workflow.py
@@ -1,9 +1,13 @@
-from .workflow import WorkflowManager
+import asyncio
+from agent_client import IngestAgentClient, StrategyAgentClient
+from orchestrator import PipelineOrchestrator
 
 
-def main():
-    manager = WorkflowManager("https://example.com/feed")
-    manager.run()
+def main() -> None:
+    ingest = IngestAgentClient("http://localhost:8001")
+    strategy = StrategyAgentClient("http://localhost:8002")
+    orchestrator = PipelineOrchestrator(ingest, strategy)
+    asyncio.run(orchestrator.run("https://example.com/feed"))
 
 
 if __name__ == "__main__":

--- a/spiceflow/__init__.py
+++ b/spiceflow/__init__.py
@@ -1,6 +1,6 @@
 import importlib, sys
 
-for mod in ("cli", "workflow"):
+for mod in ("cli", "workflow", "orchestrator"):
     module = importlib.import_module(mod)
     sys.modules[__name__ + f".{mod}"] = module
     setattr(sys.modules[__name__], mod, module)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,55 @@
+import asyncio
+from orchestrator import PipelineOrchestrator
+
+
+class DummyIngest:
+    def __init__(self):
+        self.calls = []
+
+    def discover(self, feed_url: str):
+        self.calls.append(("discover", feed_url))
+        return ["a.mp3", "b.mp3"]
+
+    def transcribe(self, url: str):
+        self.calls.append(("transcribe", url))
+        return f"text-{url}"
+
+
+class DummyStrategy:
+    def __init__(self):
+        self.calls = []
+
+    def analyze(self, text: str):
+        self.calls.append(("analyze", text))
+        return f"summary-{text}"
+
+
+class FailingIngest(DummyIngest):
+    def __init__(self):
+        super().__init__()
+        self.fail = True
+
+    def transcribe(self, url: str):
+        if self.fail:
+            self.fail = False
+            self.calls.append(("transcribe", url))
+            raise Exception("boom")
+        return super().transcribe(url)
+
+
+def test_orchestrator_sequential():
+    ingest = DummyIngest()
+    strategy = DummyStrategy()
+    orchestrator = PipelineOrchestrator(ingest, strategy)
+    result = asyncio.run(orchestrator.run("http://feed", limit=2))
+    assert len(result) == 2
+    assert result[0]["summary"] == "summary-text-a.mp3"
+
+
+def test_orchestrator_retry():
+    ingest = FailingIngest()
+    strategy = DummyStrategy()
+    orchestrator = PipelineOrchestrator(ingest, strategy, retries=1)
+    result = asyncio.run(orchestrator.run("http://feed", limit=1))
+    assert len(result) == 1
+    assert ingest.calls.count(("transcribe", "a.mp3")) == 2


### PR DESCRIPTION
## Summary
- orchestrate ingest and strategy agents with a new `PipelineOrchestrator`
- expose orchestrator from `spiceflow` package
- update workflow runner to use orchestrator
- test orchestrator behaviour and retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479e7ca9f4832795242701465a9c0e