### PR TITLE
Add event-driven workflow runner

### DIFF
--- a/demo.yml
+++ b/demo.yml
@@ -1,0 +1,4 @@
+feed_url: https://example.com/feed
+limit: 2
+ingest_url: http://localhost:8001
+strategy_url: http://localhost:8002

--- a/run_workflow.py
+++ b/run_workflow.py
@@ -1,14 +1,34 @@
 import asyncio
+import sys
+from pathlib import Path
 from agent_client import IngestAgentClient, StrategyAgentClient
-from orchestrator import PipelineOrchestrator
+from orchestrator import PipelineOrchestrator, EventBus
+from scheduler import _fallback_parse
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dep
+    yaml = None
 
 
-def main() -> None:
-    ingest = IngestAgentClient("http://localhost:8001")
-    strategy = StrategyAgentClient("http://localhost:8002")
-    orchestrator = PipelineOrchestrator(ingest, strategy)
-    asyncio.run(orchestrator.run("https://example.com/feed"))
+def _load(path: Path) -> dict:
+    text = path.read_text()
+    if yaml:
+        return yaml.safe_load(text) or {}
+    return _fallback_parse(text)
+
+
+def main(cfg_file: str = "demo.yml") -> None:
+    cfg = _load(Path(cfg_file))
+    ingest = IngestAgentClient(cfg.get("ingest_url", "http://localhost:8001"))
+    strategy = StrategyAgentClient(cfg.get("strategy_url", "http://localhost:8002"))
+    bus = EventBus()
+    bus.on("discovered", lambda urls: print(f"Discovered {len(urls)} URLs"))
+    bus.on("transcribed", lambda url, text: print(f"Transcribed {url}"))
+    bus.on("analyzed", lambda url, summary: print(f"Analyzed {url}"))
+    bus.on("completed", lambda results: print(f"Completed with {len(results)} results"))
+    orchestrator = PipelineOrchestrator(ingest, strategy, bus=bus)
+    asyncio.run(orchestrator.run(cfg.get("feed_url", "https://example.com/feed"), cfg.get("limit", 10)))
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1] if len(sys.argv) > 1 else "demo.yml")


### PR DESCRIPTION
## Summary
- add minimal `EventBus` and integrate with `PipelineOrchestrator`
- introduce `run_workflow` CLI for YAML workflow configuration
- provide sample `demo.yml`
- verify event emission in orchestrator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a5413e388327a212f444c5d29e9b